### PR TITLE
Update gdbm package.py

### DIFF
--- a/var/spack/repos/builtin/packages/gdbm/package.py
+++ b/var/spack/repos/builtin/packages/gdbm/package.py
@@ -28,6 +28,7 @@ class Gdbm(AutotoolsPackage, GNUMirrorPackage):
     depends_on("readline")
     patch('gdbm.patch', when='%gcc@10:')
     patch('gdbm.patch', when='%clang@11:')
+    patch('gdbm.patch', when='%aocc@2:')
 
     def configure_args(self):
 


### PR DESCRIPTION
Installing gdbm using aocc@2.3.0 fails in linking stage. Output:
```
gmt@x1:~$ spack install gdbm %aocc@2.3.0
[+] /opt/spack/linux-ubuntu20.04-ivybridge/aocc-2.3.0/pkgconf-1.7.3-s3iobsajqrxhpsd3j7ugyzyiwzrbrcuo
[+] /opt/spack/linux-ubuntu20.04-ivybridge/aocc-2.3.0/ncurses-6.2-kpcj7rayx7o6ael4c7cpj2zffmlyjgyr
[+] /opt/spack/linux-ubuntu20.04-ivybridge/aocc-2.3.0/readline-8.0-okeubv5222phnmts7t37tybzxt2f3swl
==> Installing gdbm-1.18.1-xma35uleqt5zcpje63w63zt4wivj3col
==> No binary for gdbm-1.18.1-xma35uleqt5zcpje63w63zt4wivj3col found: installing from source
==> Using cached archive: /home/gmt/.spack/cache/repo/_source-cache/archive/86/86e613527e5dba544e73208f42b78b7c022d4fa5a6d5498bf18c8d6f745b91dc.tar.gz
==> gdbm: Executing phase: 'autoreconf'
==> gdbm: Executing phase: 'configure'
==> gdbm: Executing phase: 'build'
==> Error: ProcessError: Command exited with status 2:
    'make' '-j4'

6 errors found in build log:
     225      AR       libgdbmapp.a
     226    ar: `u' modifier ignored since `D' is the default (see `U')
     227      CCLD     libgdbm.la
     228    ar: `u' modifier ignored since `D' is the default (see `U')
     229      CCLD     gdbm_load
     230      CCLD     gdbm_dump
  >> 231    ld.lld: error: duplicate symbol: parseopt_program_args
     232    >>> defined at gdbm_load.c:33
     233    >>>            gdbm_load.o:(parseopt_program_args)
     234    >>> defined at parseopt.c:259
     235    >>>            parseopt.o:(.bss+0x60) in archive ./libgdbmapp.a
     236    
  >> 237    ld.lld: error: duplicate symbol: parseopt_program_doc
     238    >>> defined at gdbm_load.c:32
     239    >>>            gdbm_load.o:(parseopt_program_doc)
     240    >>> defined at parseopt.c:258
     241    >>>            parseopt.o:(.bss+0x68) in archive ./libgdbmapp.a
  >> 242    clang-11: error: linker command failed with exit code 1 (use -v to see invo
            cation)
  >> 243    ld.lld: error: duplicate symbol: parseopt_program_args
     244    >>> defined at gdbm_dump.c:23
     245    >>>            gdbm_dump.o:(parseopt_program_args)
     246    >>> defined at parseopt.c:259
     247    >>>            parseopt.o:(.bss+0x60) in archive ./libgdbmapp.a
     248    
  >> 249    ld.lld: error: duplicate symbol: parseopt_program_doc
     250    >>> defined at gdbm_dump.c:22
     251    >>>            gdbm_dump.o:(parseopt_program_doc)
     252    >>> defined at parseopt.c:258
     253    >>>            parseopt.o:(.bss+0x68) in archive ./libgdbmapp.a
     254    make[3]: *** [Makefile:652: gdbm_load] Error 1
     255    make[3]: *** Waiting for unfinished jobs....
  >> 256    clang-11: error: linker command failed with exit code 1 (use -v to see invo
            cation)
     257    make[3]: *** [Makefile:648: gdbm_dump] Error 1
     258    make[3]: Leaving directory '/tmp/gmt/spack-stage/spack-stage-gdbm-1.18.1-xm
            a35uleqt5zcpje63w63zt4wivj3col/spack-src/src'
     259    make[2]: *** [Makefile:499: all] Error 2
     260    make[2]: Leaving directory '/tmp/gmt/spack-stage/spack-stage-gdbm-1.18.1-xm
            a35uleqt5zcpje63w63zt4wivj3col/spack-src/src'
     261    make[1]: *** [Makefile:464: all-recursive] Error 1
     262    make[1]: Leaving directory '/tmp/gmt/spack-stage/spack-stage-gdbm-1.18.1-xm
            a35uleqt5zcpje63w63zt4wivj3col/spack-src'

See build log for details:
  /tmp/gmt/spack-stage/spack-stage-gdbm-1.18.1-xma35uleqt5zcpje63w63zt4wivj3col/spack-build-out.txt
```

This fixes the problem.
